### PR TITLE
extern C for disorder include

### DIFF
--- a/SmithWatermanGotoh.h
+++ b/SmithWatermanGotoh.h
@@ -9,7 +9,9 @@
 #include <string.h>
 #include <sstream>
 #include <string>
+extern "C" {
 #include "disorder.h"
+}
 #include "Repeats.h"
 #include "LeftAlign.h"
 


### PR DESCRIPTION
Hi Erik, I've been exploring wrapping vcflib via Cython and find I need the disorder.h include to be wrapped with extern "C". 
