### PR TITLE
don't pass the -s argument to the linker -- breaks build on Mac OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ OBJECTS= $(SOURCES:.cpp=.o) disorder.o
 # ----------------
 
 CFLAGS=-Wall -O3
-LDFLAGS=-Wl,-s
+# Note - passing -s to the clang linker in Xcode 5.1.1 cause the build to fail
+#LDFLAGS=-Wl,-s
 #CFLAGS=-g
 PROGRAM=smithwaterman
 LIBS=


### PR DESCRIPTION
using LDFLAGS=-Wl,-s on Mac OSX breaks the build.  On Linux, omitting this argument works fine, but results in a 50% larger smithwaterman binary.

Is it important to retain the binary stripping step? If so I could add a strip step to the smithwaterman rule.
