### PR TITLE
Add package-manager-friendly install targets and tunable variables, shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,13 @@ OBJECTS_NO_MAIN= disorder.o BandedSmithWaterman.o SmithWatermanGotoh.o Repeats.o
 # compiler options
 # ----------------
 
-# Use ?= to allow overriding from the env or command-line.
-# Many of these variables are automatically set by package managers
-# and can easily be controlled by the package maintainer.
+# Use ?= to allow overriding from the env or command-line, e.g.
+#
+#       make CXXFLAGS="-O3 -fPIC" install
+#
+# Package managers will override many of these variables automatically, so
+# this is aimed at making it easy to create packages (Debian packages,
+# FreeBSD ports, MacPorts, pkgsrc, etc.)
 
 CXX ?=		c++
 CXXFLAGS ?=	-O3
@@ -35,7 +39,7 @@ BIN:=		smithwaterman
 LIB =		libsw.a
 SLIB =		libsw.so
 
-all: $(BIN) $(LIB) $(SLIB)
+all: $(BIN) $(LIB) $(SLIB) sw.o
 
 .PHONY: all
 

--- a/Makefile
+++ b/Makefile
@@ -17,27 +17,26 @@ OBJECTS_NO_MAIN= disorder.o BandedSmithWaterman.o SmithWatermanGotoh.o Repeats.o
 # Use ?= to allow overriding from the env or command-line
 CXX?=		c++
 CXXFLAGS?=	-O3
-OBJ?=		sw.o
+#CXXFLAGS+=	-g
 
 # I don't think := is useful here, since there is nothing to expand
 LDFLAGS:=	-Wl,-s
-#CXXFLAGS=-g
 EXE:=		smithwaterman
 LIBS=
 
-all: $(EXE) $(OBJ)
+all: $(EXE) sw.o libsw.a
 
 .PHONY: all
 
-libsw.a: smithwaterman.o BandedSmithWaterman.o SmithWatermanGotoh.o LeftAlign.o Repeats.o IndelAllele.o disorder.o
-	ar rs $@ smithwaterman.o SmithWatermanGotoh.o disorder.o BandedSmithWaterman.o LeftAlign.o Repeats.o IndelAllele.o
+libsw.a: $(OBJECTS_NO_MAIN)
+	ar rs $@ $(OBJECTS_NO_MAIN)
 
-sw.o:  BandedSmithWaterman.o SmithWatermanGotoh.o LeftAlign.o Repeats.o IndelAllele.o disorder.o
+sw.o:  $(OBJECTS_NO_MAIN)
 	ld -r $^ -o sw.o -L.
-	#$(CXX) $(CFLAGS) -c -o smithwaterman.cpp $(OBJECTS_NO_MAIN) -I.
+	@#$(CXX) $(CFLAGS) -c -o smithwaterman.cpp $(OBJECTS_NO_MAIN) -I.
 
 ### @$(CXX) $(LDFLAGS) $(CFLAGS) -o $@ $^ -I.
-$(EXE): smithwaterman.o BandedSmithWaterman.o SmithWatermanGotoh.o disorder.o LeftAlign.o Repeats.o IndelAllele.o
+$(EXE): $(OBJECTS)
 	$(CXX) $(CFLAGS) $^ -I. -o $@
 
 #smithwaterman: $(OBJECTS)
@@ -48,14 +47,19 @@ smithwaterman.o: smithwaterman.cpp disorder.o
 
 disorder.o: disorder.cpp disorder.h
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -I.
+
 BandedSmithWaterman.o: BandedSmithWaterman.cpp BandedSmithWaterman.h
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -I.
+
 SmithWatermanGotoh.o: SmithWatermanGotoh.cpp SmithWatermanGotoh.h disorder.o
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -I.
+
 Repeats.o: Repeats.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -I.
+
 LeftAlign.o: LeftAlign.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -I.
+
 IndelAllele.o: IndelAllele.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -I.
 
@@ -63,4 +67,4 @@ IndelAllele.o: IndelAllele.cpp
 
 clean:
 	@echo "Cleaning up."
-	@rm -f *.o $(PROGRAM) *~
+	@rm -f *.o $(PROGRAM) *~ *.a

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,7 @@ LDFLAGS:=	-Wl,-s
 BIN =		smithwaterman
 LIB =		libsw.a
 SOVERSION =	1
-SLIB_BARE =	libsw.so
-SLIB =		$(SLIB_BARE).$(SOVERSION)
+SLIB =		libsw.so.$(SOVERSION)
 
 all: $(BIN) $(LIB) $(SLIB) sw.o
 
@@ -49,8 +48,7 @@ $(LIB): $(OBJECTS_NO_MAIN)
 	ar rs $@ $(OBJECTS_NO_MAIN)
 
 $(SLIB): $(OBJECTS_NO_MAIN)
-	$(CXX) -shared -Wl,-soname,$(SLIB) \
-		-o $(SLIB) $(OBJECTS_NO_MAIN)
+	$(CXX) -shared -Wl,-soname,$(SLIB) -o $(SLIB) $(OBJECTS_NO_MAIN)
 
 sw.o:  $(OBJECTS_NO_MAIN)
 	ld -r $^ -o sw.o -L.
@@ -91,8 +89,6 @@ install: all
 	$(INSTALL) $(BIN) $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) *.h $(DESTDIR)$(PREFIX)/include/smithwaterman
 	$(INSTALL) $(LIB) $(SLIB) $(DESTDIR)$(PREFIX)/lib
-	$(LN) -s $(DESTDIR)$(PREFIX)/lib/$(SLIB) \
-		$(DESTDIR)$(PREFIX)/lib/$(SLIB_BARE)
 
 install-strip: install
 	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(BIN) $(DESTDIR)$(PREFIX)/lib/$(SLIB)
@@ -101,4 +97,4 @@ install-strip: install
 
 clean:
 	@echo "Cleaning up."
-	@rm -rf $(BIN) $(LIB) $(SLIB) $(SLIB_BARE) $(OBJECTS) $(DESTDIR)
+	@rm -rf $(BIN) $(LIB) $(SLIB) $(OBJECTS) $(DESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,14 @@ STRIP ?=	strip
 INSTALL ?=	install -c
 MKDIR ?=	mkdir -p
 AR ?=		ar
+LN ?=		ln
 
-# FIXME: I don't think := is useful here, since there is nothing to expand
 LDFLAGS:=	-Wl,-s
-BIN:=		smithwaterman
+BIN =		smithwaterman
 LIB =		libsw.a
-SLIB =		libsw.so
+SOVERSION =	1
+SLIB_BARE =	libsw.so
+SLIB =		$(SLIB_BARE).$(SOVERSION)
 
 all: $(BIN) $(LIB) $(SLIB) sw.o
 
@@ -47,7 +49,8 @@ $(LIB): $(OBJECTS_NO_MAIN)
 	ar rs $@ $(OBJECTS_NO_MAIN)
 
 $(SLIB): $(OBJECTS_NO_MAIN)
-	${CXX} -shared -Wl,-soname,$(SLIB).1 -o $(SLIB) $(OBJECTS_NO_MAIN)
+	$(CXX) -shared -Wl,-soname,$(SLIB) \
+		-o $(SLIB) $(OBJECTS_NO_MAIN)
 
 sw.o:  $(OBJECTS_NO_MAIN)
 	ld -r $^ -o sw.o -L.
@@ -88,6 +91,8 @@ install: all
 	$(INSTALL) $(BIN) $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) *.h $(DESTDIR)$(PREFIX)/include/smithwaterman
 	$(INSTALL) $(LIB) $(SLIB) $(DESTDIR)$(PREFIX)/lib
+	$(LN) -s $(DESTDIR)$(PREFIX)/lib/$(SLIB) \
+		$(DESTDIR)$(PREFIX)/lib/$(SLIB_BARE)
 
 install-strip: install
 	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(BIN) $(DESTDIR)$(PREFIX)/lib/$(SLIB)
@@ -96,4 +101,4 @@ install-strip: install
 
 clean:
 	@echo "Cleaning up."
-	@rm -rf $(BIN) $(LIB) $(SLIB) $(OBJECTS) $(DESTDIR)
+	@rm -rf $(BIN) $(LIB) $(SLIB) $(SLIB_BARE) $(OBJECTS) $(DESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LDFLAGS:=	-Wl,-s
 EXE:=		smithwaterman
 LIBS=
 
-all: $(EXE) sw.o libsw.a
+all: $(EXE) libsw.a
 
 .PHONY: all
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ OBJECTS_NO_MAIN= disorder.o BandedSmithWaterman.o SmithWatermanGotoh.o Repeats.o
 
 CXX ?=		c++
 CXXFLAGS ?=	-O3
+CXXFLAGS +=	-fPIC
 DESTDIR ?=	stage
 PREFIX ?=	/usr/local
 STRIP ?=	strip
@@ -32,13 +33,17 @@ AR ?=		ar
 LDFLAGS:=	-Wl,-s
 BIN:=		smithwaterman
 LIB =		libsw.a
+SLIB =		libsw.so
 
-all: $(BIN) $(LIB)
+all: $(BIN) $(LIB) $(SLIB)
 
 .PHONY: all
 
 $(LIB): $(OBJECTS_NO_MAIN)
 	ar rs $@ $(OBJECTS_NO_MAIN)
+
+$(SLIB): $(OBJECTS_NO_MAIN)
+	${CXX} -shared -Wl,-soname,$(SLIB).1 -o $(SLIB) $(OBJECTS_NO_MAIN)
 
 sw.o:  $(OBJECTS_NO_MAIN)
 	ld -r $^ -o sw.o -L.
@@ -78,13 +83,13 @@ install: all
 	$(MKDIR) $(DESTDIR)$(PREFIX)/lib
 	$(INSTALL) $(BIN) $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) *.h $(DESTDIR)$(PREFIX)/include/smithwaterman
-	$(INSTALL) $(LIB) $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) $(LIB) $(SLIB) $(DESTDIR)$(PREFIX)/lib
 
 install-strip: install
-	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(BIN)
+	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(BIN) $(DESTDIR)$(PREFIX)/lib/$(SLIB)
 
 .PHONY: clean
 
 clean:
 	@echo "Cleaning up."
-	@rm -rf $(BIN) $(LIB) $(OBJECTS) $(DESTDIR)
+	@rm -rf $(BIN) $(LIB) $(SLIB) $(OBJECTS) $(DESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ all: $(BIN) $(LIB) $(SLIB) sw.o
 .PHONY: all
 
 $(LIB): $(OBJECTS_NO_MAIN)
-	ar rs $@ $(OBJECTS_NO_MAIN)
+	$(AR) rs $@ $(OBJECTS_NO_MAIN)
 
 $(SLIB): $(OBJECTS_NO_MAIN)
 	$(CXX) -shared -Wl,-soname,$(SLIB) -o $(SLIB) $(OBJECTS_NO_MAIN)


### PR DESCRIPTION
Tested both separate build and integrated build under vcflib on my end, but I recommend retesting on your platform following each pull just to be sure.